### PR TITLE
fix(countAllOn): forgot to inclement index

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function countAllOn(x, fn=null, ths=null) {
   var fn = fn||id;
   var m = new Map(), i = -1;
   for(var v of x) {
-    var v1 = fn.call(ths, v, i, x);
+    var v1 = fn.call(ths, v, ++i, x);
     m.set((m.get(v1)||0) + 1);
   }
   return m;


### PR DESCRIPTION
The value of a map function's 2nd argument passed from countAllOn is always `-1`.

Note: I've checked all the code around calling `fn.call` in `index.js`. This is the only place forgot to inclement index.