### PR TITLE
Add sideEffects directive to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "require": "./index.js",
     "import": "./index.mjs"
   },
+  "sideEffects": false,
   "scripts": {
     "test": "exit",
     "build": "ebuild export+main+example+wiki+readme --wikiExample=false --asciinema=false",


### PR DESCRIPTION
The sideEffects directive can help module bundlers remove unused imports. By asserting that this package doesn't have side effects, it's safe to remove `import "extra-array/*"` and its contents, if none of the imports are used.

Here's some docs, in case you aren't familiar. It's in the webpack website, but bundlers in general adopt this convention.

https://webpack.js.org/guides/tree-shaking/

Thanks for this project. I'll work a lot on arrays, and I like that so many utilities are available in one place!